### PR TITLE
Upgrade Laravel Sail to avoid using Ubuntu v21.10

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5837,16 +5837,16 @@
         },
         {
             "name": "laravel/sail",
-            "version": "v1.13.9",
+            "version": "v1.16.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/sail.git",
-                "reference": "7bb294fe99fc42c3b1bee83fb667cd7698b3c385"
+                "reference": "7d1ed5f856ec8b9708712e3fc0708fcabe114659"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/sail/zipball/7bb294fe99fc42c3b1bee83fb667cd7698b3c385",
-                "reference": "7bb294fe99fc42c3b1bee83fb667cd7698b3c385",
+                "url": "https://api.github.com/repos/laravel/sail/zipball/7d1ed5f856ec8b9708712e3fc0708fcabe114659",
+                "reference": "7d1ed5f856ec8b9708712e3fc0708fcabe114659",
                 "shasum": ""
             },
             "require": {


### PR DESCRIPTION
The setup of this repo through Laravel Sail was failing due to the `composer.lock` file pointing to Laravel Sail v1.13.9.

That specific version of Sail was using Ubuntu v21.10 which was deprecated on the 14th of July.

Upgrading Laravel Sail to the version 1.16.2 lets us use Ubuntu v22.04 and concludes the installation successfully.